### PR TITLE
test : 중복 우승자 처리 테스트 및 여러 에러 처리 테스트 추가

### DIFF
--- a/src/test/java/racingcar/ApplicationTest.java
+++ b/src/test/java/racingcar/ApplicationTest.java
@@ -24,12 +24,40 @@ class ApplicationTest extends NsTest {
     }
 
     @Test
+    void 중복_우승자_기능_테스트(){
+        assertRandomNumberInRangeTest(
+                () -> {
+                    run("pobi,woni", "2");
+                    assertThat(output()).contains("pobi : -", "woni : -", "최종 우승자 : pobi, woni");
+                },
+                MOVING_FORWARD, MOVING_FORWARD, STOP
+        );
+    }
+
+    @Test
     void 예외_테스트() {
         assertSimpleTest(() ->
             assertThatThrownBy(() -> runException("pobi,javaji", "1"))
                 .isInstanceOf(IllegalArgumentException.class)
         );
     }
+
+//    @Test
+//    void 중복_이름_예외_테스트(){
+//        assertSimpleTest(() ->
+//                assertThatThrownBy(() -> runException("pobi,pobi", "1"))
+//                .isInstanceOf(IllegalArgumentException.class)
+//        );
+//    }
+//
+//    @Test
+//    void 단일_후보_예외_테스트(){
+//        assertSimpleTest(() ->
+//                assertThatThrownBy(() -> runException("pobi", "1"))
+//                        .isInstanceOf(IllegalArgumentException.class)
+//        );
+//    }
+//
 
     @Override
     public void runMain() {


### PR DESCRIPTION
# 구현 사항
1. 정상 테스트 케이스 추가
&emsp; a. 중복 우승자 발생 경우 추가
2. 오류 테스트 케이스 추가
&emsp; a. 중복 이름 입력 경우 추가
&emsp; b. 단일 후보 입력 경우 추가

# 참고
- 오류 테스트 케이스는, 각 케이스에서 발생하는 프로그램 종료로 인하여 하나씩만 실행 가능함. 따라서 몇 테스트 케이스들을 주석 처리 되어 있음.